### PR TITLE
remove cgo compile flag

### DIFF
--- a/op-enclave/Dockerfile
+++ b/op-enclave/Dockerfile
@@ -15,7 +15,7 @@ RUN go mod download
 
 COPY . .
 
-RUN CGO_ENABLED=0 go build -o bin/enclave ./cmd/enclave
+RUN go build -o bin/enclave ./cmd/enclave
 
 COPY eif eif/
 COPY --from=bootstrap /build/out bootstrap


### PR DESCRIPTION
### Description
remove CGO_ENABLED=0, it is tested that the eif.bin image works without CGO_ENABLED=0 

### Rationale

N/A.

### Example

N/A.

### Changes

Notable changes:
* Dockerfile