### PR TITLE
support libstdc++ dependency in dockerfile

### DIFF
--- a/op-batcher/Dockerfile
+++ b/op-batcher/Dockerfile
@@ -16,7 +16,7 @@ RUN make op-batcher TARGETOS=$TARGETOS TARGETARCH=$TARGETARCH
 
 FROM alpine:3.19
 
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates libstdc++
 
 COPY --from=builder /app/op-batcher/bin/op-batcher /usr/local/bin
 

--- a/op-proposer/Dockerfile
+++ b/op-proposer/Dockerfile
@@ -16,7 +16,7 @@ RUN make op-proposer TARGETOS=$TARGETOS TARGETARCH=$TARGETARCH
 
 FROM alpine:3.19
 
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates libstdc++
 
 COPY --from=builder /app/op-proposer/bin/op-proposer /usr/local/bin
 


### PR DESCRIPTION
### Description
support libstdc++ dependency in dockerfile
```
Error loading shared library libstdc++.so.6: No such file or directory (needed by /usr/local/bin/op-batcher)
Error relocating /usr/local/bin/op-batcher: __cxa_guard_release: symbol not found
Error relocating /usr/local/bin/op-batcher: __cxa_guard_acquire: symbol not found

``` 

### Rationale

N/A.

### Example

N/A.

### Changes

Notable changes:
* Dockerfile