### PR TITLE
fix: fix rpc metrics duplicated register panic

### DIFF
--- a/op-proposer/metrics/metrics.go
+++ b/op-proposer/metrics/metrics.go
@@ -46,6 +46,7 @@ func NewMetrics(procName string) *Metrics {
 
 	registry := opmetrics.NewRegistry()
 	factory := opmetrics.With(registry)
+	txMetrics := txmetrics.MakeTxMetrics(ns, factory)
 
 	return &Metrics{
 		ns:       ns,
@@ -53,8 +54,8 @@ func NewMetrics(procName string) *Metrics {
 		factory:  factory,
 
 		RefMetrics: opmetrics.MakeRefMetrics(ns, factory),
-		TxMetrics:  txmetrics.MakeTxMetrics(ns, factory),
-		RPCMetrics: opmetrics.MakeRPCMetrics(ns, factory),
+		TxMetrics:  txMetrics,
+		RPCMetrics: txMetrics.RPCMetrics,
 
 		info: *factory.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: ns,


### PR DESCRIPTION
### Rationale
Fix rpc metrics duplicated register panic.

`
goroutine 1 [running]:
github.com/prometheus/client_golang/prometheus.(*Registry).MustRegister(0xc0000c36d0, {0xc004c9f3b0?, 0x157b2eb?, 0xa?})
	/go/pkg/mod/github.com/prometheus/client_golang@v1.21.1/prometheus/registry.go:406 +0x66
github.com/prometheus/client_golang/prometheus/promauto.Factory.NewCounterVec({{0x19dc0d0?, 0xc0000c36d0?}}, {{0xc004c9a870, 0x13}, {0x157b2eb, 0xa}, {0x1580697, 0xe}, {0x15c40cd, 0x37}, ...}, ...)
	/go/pkg/mod/github.com/prometheus/client_golang@v1.21.1/prometheus/promauto/auto.go:276 +0x163
github.com/ethereum-optimism/optimism/op-service/metrics.(*documentor).NewCounterVec(0xc004c351a0, {{0xc004c9a870, 0x13}, {0x157b2eb, 0xa}, {0x1580697, 0xe}, {0x15c40cd, 0x37}, 0x0, ...}, ...)
	/go/pkg/mod/github.com/bnb-chain/opbnb@v0.5.4-0.20250520064121-9c9dabcd4645/op-service/metrics/factory.go:54 +0x2de
github.com/ethereum-optimism/optimism/op-service/metrics.MakeRPCClientMetrics({0xc004c9a870, 0x13}, {0x19eac40, 0xc004c351a0})
	/go/pkg/mod/github.com/bnb-chain/opbnb@v0.5.4-0.20250520064121-9c9dabcd4645/op-service/metrics/rpc_metrics.go:63 +0x12f
github.com/ethereum-optimism/optimism/op-service/metrics.MakeRPCMetrics({0xc004c9a870, 0x13}, {0x19eac40, 0xc004c351a0})
	/go/pkg/mod/github.com/b
nb-chain/opbnb@v0.5.4-0.20250520064121-9c9dabcd4645/op-service/metrics/rpc_metrics.go:55 +0x45
github.com/base/op-enclave/op-proposer/metrics.NewMetrics({0x157506e?, 0x7f08835e55b8?})
	/app/op-proposer/metrics/metrics.go:57 +0x1a5
github.com/base/op-enclave/op-proposer/proposer.(*ProposerService).initMetrics(...)
	/app/op-proposer/proposer/service.go:158
github.com/base/op-enclave/op-proposer/proposer.(*ProposerService).initFromCLIConfig(0xc0003a8680, {0x19e2038, 0xc0000c3680}, {0x19cf2e4?, 0x0?}, 0xc004bedbc0, {0x19ebfe8?, 0xc0001155f0?})
	/app/op-proposer/proposer/service.go:92 +0x96
github.com/base/op-enclave/op-proposer/proposer.ProposerServiceFromCLIConfig({0x19e2038, 0xc0000c3680}, {0x19cf2e4, 0x6}, 0xc004bedbc0, {0x19ebfe8, 0xc0001155f0})
	/app/op-proposer/proposer/service.go:82 +0xa5
main.main.Main.func1(0xc004bece00, 0xc004c34e40?)
	/app/op-proposer/proposer/l2_output_submitter.go:32 +0x1b6
main.main.LifecycleCmd.func2(0xc004bece00)
	/go/pkg/mod/github.com/bnb-chain/opbnb@v0.5.4-0.20250520064121-9c9dabcd4645/op-service/cliapp/lifecycle.go:56 +0x171
github.com/urfave/cli/v2.(*Command).Run(0xc0002546e0, 0xc004bece00, {0xc000040090, 0x1, 0x1})
	/go/pkg/mod/github.com/urfave/cli/v2@v2.27.5/command.go:276 +0x97d
github.com/urfave/cli/v2.(*App).RunContext(0xc0003cca00, {0x19e2000, 0xc004c34e40}, {0xc000040090, 0x1, 0x1})
	/go/pkg/mod/github.com/urfave/cli/v2@v2.27.5/app.go:333 +0x5a5
main.main()
	/app/op-proposer/cmd/main.go:35 +0x28f
`

The rpc metrics has duplicated register due to https://github.com/bnb-chain/opbnb/blob/02ddbc331594f38c4e7c96a95510010f47f13a64/op-service/txmgr/metrics/tx_metrics.go#L64.


### Example
N/A.


### Changes

Notable changes:

- op-proposer metrics register func.


