### PR TITLE
fix: fix adap opbnb PreparePayloadAttributes workflow

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -8,8 +8,6 @@ on:
       - develop
       - main
       - adapt_opbnb
-      - fix-wrong-l1fetcher
-      - adapt_op
 
 jobs:
   push-op-enclave:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -8,6 +8,7 @@ on:
       - develop
       - main
       - adapt_opbnb
+      - fix-wrong-l1fetcher
 
 jobs:
   push-op-enclave:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -9,6 +9,7 @@ on:
       - main
       - adapt_opbnb
       - fix-wrong-l1fetcher
+      - adapt_op
 
 jobs:
   push-op-enclave:

--- a/go.mod
+++ b/go.mod
@@ -181,7 +181,8 @@ replace github.com/ethereum/go-ethereum => github.com/bnb-chain/op-geth v1.10131
 // https://github.com/bnb-chain/opbnb/tree/adapt_enclave import op-batcher/op-proposer
 // replace github.com/ethereum-optimism/optimism => github.com/bnb-chain/opbnb v0.5.4-0.20250520064121-9c9dabcd4645
 
-replace github.com/ethereum-optimism/optimism => ../opbnb
+// https://github.com/will-2012/opbnb/tree/new-adapt-enclave
+replace github.com/ethereum-optimism/optimism => github.com/will-2012/opbnb v0.0.0-20250523064839-a6ca7497dc40
 
 // fix verkle tree conflict
 replace github.com/crate-crypto/go-ipa => github.com/crate-crypto/go-ipa v0.0.0-20231205143816-408dbffb2041

--- a/go.mod
+++ b/go.mod
@@ -179,10 +179,7 @@ replace github.com/base/op-enclave/op-enclave => ./op-enclave
 replace github.com/ethereum/go-ethereum => github.com/bnb-chain/op-geth v1.101315.2-0.0.20250520053659-1fde7613d115
 
 // https://github.com/bnb-chain/opbnb/tree/adapt_enclave import op-batcher/op-proposer
-// replace github.com/ethereum-optimism/optimism => github.com/bnb-chain/opbnb v0.5.4-0.20250520064121-9c9dabcd4645
-
-// https://github.com/will-2012/opbnb/tree/new-adapt-enclave
-replace github.com/ethereum-optimism/optimism => github.com/will-2012/opbnb v0.0.0-20250523064839-a6ca7497dc40
+replace github.com/ethereum-optimism/optimism => github.com/bnb-chain/opbnb v0.5.4-0.20250523084526-116cdea15e13
 
 // fix verkle tree conflict
 replace github.com/crate-crypto/go-ipa => github.com/crate-crypto/go-ipa v0.0.0-20231205143816-408dbffb2041

--- a/go.mod
+++ b/go.mod
@@ -179,7 +179,9 @@ replace github.com/base/op-enclave/op-enclave => ./op-enclave
 replace github.com/ethereum/go-ethereum => github.com/bnb-chain/op-geth v1.101315.2-0.0.20250520053659-1fde7613d115
 
 // https://github.com/bnb-chain/opbnb/tree/adapt_enclave import op-batcher/op-proposer
-replace github.com/ethereum-optimism/optimism => github.com/bnb-chain/opbnb v0.5.4-0.20250520064121-9c9dabcd4645
+// replace github.com/ethereum-optimism/optimism => github.com/bnb-chain/opbnb v0.5.4-0.20250520064121-9c9dabcd4645
+
+replace github.com/ethereum-optimism/optimism => ../opbnb
 
 // fix verkle tree conflict
 replace github.com/crate-crypto/go-ipa => github.com/crate-crypto/go-ipa v0.0.0-20231205143816-408dbffb2041

--- a/go.sum
+++ b/go.sum
@@ -998,8 +998,6 @@ github.com/bnb-chain/greenfield-cometbft v1.0.0 h1:0r6hOJWD/+es0gxP/exKuN/krgXAr
 github.com/bnb-chain/greenfield-cometbft v1.0.0/go.mod h1:f35mk/r5ab6yvzlqEWZt68LfUje68sYgMpVlt2CUYMk=
 github.com/bnb-chain/op-geth v1.101315.2-0.0.20250520053659-1fde7613d115 h1:zIqD55hPe6tiZPrOhR8x40MV8iQNjjouajkmmmf6qZo=
 github.com/bnb-chain/op-geth v1.101315.2-0.0.20250520053659-1fde7613d115/go.mod h1:hyHrrcHkUe3lRwfJs+JGrbOHp+pRdheRk+ren4TPhF8=
-github.com/bnb-chain/opbnb v0.5.4-0.20250520064121-9c9dabcd4645 h1:DDapHlH3qamNMUMX0BI5UjzJ9pqEtcM8tu7r2bFatDw=
-github.com/bnb-chain/opbnb v0.5.4-0.20250520064121-9c9dabcd4645/go.mod h1:f79+CBEK7HYPacx80akhTpzUaGZDe+tQR53TwNgFQKI=
 github.com/bombsimon/wsl/v2 v2.0.0/go.mod h1:mf25kr/SqFEPhhcxW1+7pxzGlW+hIl/hYTKY95VwV8U=
 github.com/bombsimon/wsl/v2 v2.2.0/go.mod h1:Azh8c3XGEJl9LyX0/sFC+CKMc7Ssgua0g+6abzXN4Pg=
 github.com/bombsimon/wsl/v3 v3.0.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=

--- a/go.sum
+++ b/go.sum
@@ -3682,6 +3682,8 @@ github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc/go.mod h1
 github.com/whyrusleeping/mdns v0.0.0-20190826153040-b9b60ed33aa9/go.mod h1:j4l84WPFclQPj320J9gp0XwNKBb3U0zt5CBqjPp22G4=
 github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7/go.mod h1:X2c0RVCI1eSUFI8eLcY3c0423ykwiUdxLJtkDvruhjI=
 github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee/go.mod h1:m2aV4LZI4Aez7dP5PMyVKEHhUyEJ/RjmPEDOpDvudHg=
+github.com/will-2012/opbnb v0.0.0-20250523064839-a6ca7497dc40 h1:72NTJL67fX+YQ/E5vEnmFtNQ5KjoDaKdTuyw4d/aysY=
+github.com/will-2012/opbnb v0.0.0-20250523064839-a6ca7497dc40/go.mod h1:f79+CBEK7HYPacx80akhTpzUaGZDe+tQR53TwNgFQKI=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2/go.mod h1:2duySbKsL6M18s5GU7VPsoEPHyzalCE06qoARUCeBBE=

--- a/go.sum
+++ b/go.sum
@@ -998,6 +998,8 @@ github.com/bnb-chain/greenfield-cometbft v1.0.0 h1:0r6hOJWD/+es0gxP/exKuN/krgXAr
 github.com/bnb-chain/greenfield-cometbft v1.0.0/go.mod h1:f35mk/r5ab6yvzlqEWZt68LfUje68sYgMpVlt2CUYMk=
 github.com/bnb-chain/op-geth v1.101315.2-0.0.20250520053659-1fde7613d115 h1:zIqD55hPe6tiZPrOhR8x40MV8iQNjjouajkmmmf6qZo=
 github.com/bnb-chain/op-geth v1.101315.2-0.0.20250520053659-1fde7613d115/go.mod h1:hyHrrcHkUe3lRwfJs+JGrbOHp+pRdheRk+ren4TPhF8=
+github.com/bnb-chain/opbnb v0.5.4-0.20250523084526-116cdea15e13 h1:nba63VbYo3dAllaX3Jr5GjgnTqvSKOWvH5D23D1FEb4=
+github.com/bnb-chain/opbnb v0.5.4-0.20250523084526-116cdea15e13/go.mod h1:f79+CBEK7HYPacx80akhTpzUaGZDe+tQR53TwNgFQKI=
 github.com/bombsimon/wsl/v2 v2.0.0/go.mod h1:mf25kr/SqFEPhhcxW1+7pxzGlW+hIl/hYTKY95VwV8U=
 github.com/bombsimon/wsl/v2 v2.2.0/go.mod h1:Azh8c3XGEJl9LyX0/sFC+CKMc7Ssgua0g+6abzXN4Pg=
 github.com/bombsimon/wsl/v3 v3.0.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=
@@ -3682,8 +3684,6 @@ github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc/go.mod h1
 github.com/whyrusleeping/mdns v0.0.0-20190826153040-b9b60ed33aa9/go.mod h1:j4l84WPFclQPj320J9gp0XwNKBb3U0zt5CBqjPp22G4=
 github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7/go.mod h1:X2c0RVCI1eSUFI8eLcY3c0423ykwiUdxLJtkDvruhjI=
 github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee/go.mod h1:m2aV4LZI4Aez7dP5PMyVKEHhUyEJ/RjmPEDOpDvudHg=
-github.com/will-2012/opbnb v0.0.0-20250523064839-a6ca7497dc40 h1:72NTJL67fX+YQ/E5vEnmFtNQ5KjoDaKdTuyw4d/aysY=
-github.com/will-2012/opbnb v0.0.0-20250523064839-a6ca7497dc40/go.mod h1:f79+CBEK7HYPacx80akhTpzUaGZDe+tQR53TwNgFQKI=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2/go.mod h1:2duySbKsL6M18s5GU7VPsoEPHyzalCE06qoARUCeBBE=

--- a/op-enclave/enclave/client.go
+++ b/op-enclave/enclave/client.go
@@ -2,6 +2,7 @@ package enclave
 
 import (
 	"context"
+	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
@@ -51,9 +52,9 @@ func (c *Client) SetSignerKey(ctx context.Context, encrypted hexutil.Bytes) erro
 	return c.callContext(ctx, nil, "setSignerKey", encrypted)
 }
 
-func (c *Client) ExecuteStateless(ctx context.Context, config *PerChainConfig, chainConfig *params.ChainConfig, l1Origin *types.Header, l1Receipts types.Receipts, l1Txs []hexutil.Bytes, previousBlockTxs []hexutil.Bytes, blockHeader *types.Header, sequencedTxs []hexutil.Bytes, witness *stateless.ExecutionWitness, messageAccount *eth.AccountResult, prevMessageAccountHash common.Hash) (*Proposal, error) {
+func (c *Client) ExecuteStateless(ctx context.Context, config *PerChainConfig, chainConfig *params.ChainConfig, l1Origin *types.Header, l1Receipts types.Receipts, l1BaseFee *big.Int, previousBlockTxs []hexutil.Bytes, blockHeader *types.Header, sequencedTxs []hexutil.Bytes, witness *stateless.ExecutionWitness, messageAccount *eth.AccountResult, prevMessageAccountHash common.Hash) (*Proposal, error) {
 	var result Proposal
-	return &result, c.callContext(ctx, &result, "executeStateless", config, chainConfig, l1Origin, l1Receipts, l1Txs, previousBlockTxs, blockHeader, sequencedTxs, witness, messageAccount, prevMessageAccountHash)
+	return &result, c.callContext(ctx, &result, "executeStateless", config, chainConfig, l1Origin, l1Receipts, l1BaseFee, previousBlockTxs, blockHeader, sequencedTxs, witness, messageAccount, prevMessageAccountHash)
 }
 
 func (c *Client) Aggregate(ctx context.Context, configHash common.Hash, prevOutputRoot common.Hash, proposals []*Proposal) (*Proposal, error) {

--- a/op-enclave/enclave/client.go
+++ b/op-enclave/enclave/client.go
@@ -51,9 +51,9 @@ func (c *Client) SetSignerKey(ctx context.Context, encrypted hexutil.Bytes) erro
 	return c.callContext(ctx, nil, "setSignerKey", encrypted)
 }
 
-func (c *Client) ExecuteStateless(ctx context.Context, config *PerChainConfig, chainConfig *params.ChainConfig, l1Origin *types.Header, l1Receipts types.Receipts, previousBlockTxs []hexutil.Bytes, blockHeader *types.Header, sequencedTxs []hexutil.Bytes, witness *stateless.ExecutionWitness, messageAccount *eth.AccountResult, prevMessageAccountHash common.Hash) (*Proposal, error) {
+func (c *Client) ExecuteStateless(ctx context.Context, config *PerChainConfig, chainConfig *params.ChainConfig, l1Origin *types.Header, l1Receipts types.Receipts, l1Txs []hexutil.Bytes, previousBlockTxs []hexutil.Bytes, blockHeader *types.Header, sequencedTxs []hexutil.Bytes, witness *stateless.ExecutionWitness, messageAccount *eth.AccountResult, prevMessageAccountHash common.Hash) (*Proposal, error) {
 	var result Proposal
-	return &result, c.callContext(ctx, &result, "executeStateless", config, chainConfig, l1Origin, l1Receipts, previousBlockTxs, blockHeader, sequencedTxs, witness, messageAccount, prevMessageAccountHash)
+	return &result, c.callContext(ctx, &result, "executeStateless", config, chainConfig, l1Origin, l1Receipts, l1Txs, previousBlockTxs, blockHeader, sequencedTxs, witness, messageAccount, prevMessageAccountHash)
 }
 
 func (c *Client) Aggregate(ctx context.Context, configHash common.Hash, prevOutputRoot common.Hash, proposals []*Proposal) (*Proposal, error) {

--- a/op-enclave/enclave/l1_receipts_fetcher.go
+++ b/op-enclave/enclave/l1_receipts_fetcher.go
@@ -20,16 +20,14 @@ type l1ReceiptsFetcher struct {
 	hash     common.Hash
 	header   *types.Header
 	receipts types.Receipts
-	txs      types.Transactions
 	cfg      *params.ChainConfig
 }
 
-func NewL1ReceiptsFetcher(hash common.Hash, header *types.Header, receipts types.Receipts, txs types.Transactions, cfg *params.ChainConfig) derive.L1ReceiptsFetcher {
+func NewL1ReceiptsFetcher(hash common.Hash, header *types.Header, receipts types.Receipts, cfg *params.ChainConfig) derive.L1ReceiptsFetcher {
 	return &l1ReceiptsFetcher{
 		hash:     hash,
 		header:   header,
 		receipts: receipts,
-		txs:      txs,
 		cfg:      cfg,
 	}
 }
@@ -59,7 +57,7 @@ func (l *l1ReceiptsFetcher) InfoAndTxsByHash(ctx context.Context, hash common.Ha
 		return nil, nil, errors.New("not found")
 	}
 	b := types.NewBlockWithHeader(l.header)
-	return eth.BlockToInfo(b), l.txs, nil
+	return eth.BlockToInfo(b), nil, nil
 }
 
 func (l *l1ReceiptsFetcher) PreFetchReceipts(ctx context.Context, blockHash common.Hash) (bool, error) {

--- a/op-enclave/enclave/l1_receipts_fetcher.go
+++ b/op-enclave/enclave/l1_receipts_fetcher.go
@@ -56,7 +56,8 @@ func (l *l1ReceiptsFetcher) InfoAndTxsByHash(ctx context.Context, hash common.Ha
 	if l.hash != hash {
 		return nil, nil, errors.New("not found")
 	}
-	return nil /*return nil due to caller does not use it*/, l.txs, nil
+	b := types.NewBlockWithHeader(l.header)
+	return eth.BlockToInfo(b), l.txs, nil
 }
 
 func (l *l1ReceiptsFetcher) PreFetchReceipts(ctx context.Context, blockHash common.Hash) (bool, error) {

--- a/op-enclave/enclave/l1_receipts_fetcher.go
+++ b/op-enclave/enclave/l1_receipts_fetcher.go
@@ -19,8 +19,8 @@ import (
 type l1ReceiptsFetcher struct {
 	hash     common.Hash
 	header   *types.Header
-	txs      types.Transactions
 	receipts types.Receipts
+	txs      types.Transactions
 	cfg      *params.ChainConfig
 }
 
@@ -55,7 +55,7 @@ func (l *l1ReceiptsFetcher) FetchReceipts(ctx context.Context, blockHash common.
 
 func (l *l1ReceiptsFetcher) InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error) {
 	if l.hash != hash {
-		log.Warn("debug witness, InfoAndTxsByHash", "expected_l1_hash", l.hash, "actual_l1_hash", hash)
+		log.Warn("debug witness, InfoAndTxsByHash", "expected_l1_hash", l.hash, "actual_l1_hash", hash, "l1_header", l.header)
 		return nil, nil, errors.New("not found")
 	}
 	b := types.NewBlockWithHeader(l.header)

--- a/op-enclave/enclave/l1_receipts_fetcher.go
+++ b/op-enclave/enclave/l1_receipts_fetcher.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/holiman/uint256"
@@ -54,6 +55,7 @@ func (l *l1ReceiptsFetcher) FetchReceipts(ctx context.Context, blockHash common.
 
 func (l *l1ReceiptsFetcher) InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error) {
 	if l.hash != hash {
+		log.Warn("debug witness, InfoAndTxsByHash", "expected_l1_hash", l.hash, "actual_l1_hash", hash)
 		return nil, nil, errors.New("not found")
 	}
 	b := types.NewBlockWithHeader(l.header)

--- a/op-enclave/enclave/l1_receipts_fetcher.go
+++ b/op-enclave/enclave/l1_receipts_fetcher.go
@@ -53,7 +53,6 @@ func (l *l1ReceiptsFetcher) FetchReceipts(ctx context.Context, blockHash common.
 }
 
 func (l *l1ReceiptsFetcher) InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error) {
-	//return nil, nil, errors.New("not implemented")
 	if l.hash != hash {
 		return nil, nil, errors.New("not found")
 	}
@@ -144,7 +143,6 @@ func (h headerInfo) HeaderRLP() ([]byte, error) {
 	return rlp.EncodeToBytes(h.Header)
 }
 
-// TODO: fix me
 func (h headerInfo) MillisecondTimestamp() uint64 {
 	if h.Header.MixDigest == (common.Hash{}) {
 		return 0

--- a/op-enclave/enclave/l1_receipts_fetcher.go
+++ b/op-enclave/enclave/l1_receipts_fetcher.go
@@ -18,15 +18,17 @@ import (
 type l1ReceiptsFetcher struct {
 	hash     common.Hash
 	header   *types.Header
+	txs      types.Transactions
 	receipts types.Receipts
 	cfg      *params.ChainConfig
 }
 
-func NewL1ReceiptsFetcher(hash common.Hash, header *types.Header, receipts types.Receipts, cfg *params.ChainConfig) derive.L1ReceiptsFetcher {
+func NewL1ReceiptsFetcher(hash common.Hash, header *types.Header, receipts types.Receipts, txs types.Transactions, cfg *params.ChainConfig) derive.L1ReceiptsFetcher {
 	return &l1ReceiptsFetcher{
 		hash:     hash,
 		header:   header,
 		receipts: receipts,
+		txs:      txs,
 		cfg:      cfg,
 	}
 }
@@ -51,7 +53,11 @@ func (l *l1ReceiptsFetcher) FetchReceipts(ctx context.Context, blockHash common.
 }
 
 func (l *l1ReceiptsFetcher) InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error) {
-	return nil, nil, errors.New("not implemented")
+	//return nil, nil, errors.New("not implemented")
+	if l.hash != hash {
+		return nil, nil, errors.New("not found")
+	}
+	return nil /*return nil due to caller does not use it*/, l.txs, nil
 }
 
 func (l *l1ReceiptsFetcher) PreFetchReceipts(ctx context.Context, blockHash common.Hash) (bool, error) {

--- a/op-enclave/enclave/l1_receipts_fetcher.go
+++ b/op-enclave/enclave/l1_receipts_fetcher.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/holiman/uint256"
@@ -52,12 +51,7 @@ func (l *l1ReceiptsFetcher) FetchReceipts(ctx context.Context, blockHash common.
 }
 
 func (l *l1ReceiptsFetcher) InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error) {
-	if l.hash != hash {
-		log.Warn("debug witness, InfoAndTxsByHash", "expected_l1_hash", l.hash, "actual_l1_hash", hash, "l1_header", l.header)
-		return nil, nil, errors.New("not found")
-	}
-	b := types.NewBlockWithHeader(l.header)
-	return eth.BlockToInfo(b), nil, nil
+	return nil, nil, errors.New("not implemented")
 }
 
 func (l *l1ReceiptsFetcher) PreFetchReceipts(ctx context.Context, blockHash common.Hash) (bool, error) {

--- a/op-enclave/enclave/rpc.go
+++ b/op-enclave/enclave/rpc.go
@@ -26,6 +26,7 @@ type RPC interface {
 		chainConfig *params.ChainConfig,
 		l1Origin *types.Header,
 		l1Receipts types.Receipts,
+		l1Txs []hexutil.Bytes,
 		previousBlockTxs []hexutil.Bytes,
 		blockHeader *types.Header,
 		sequencedTxs []hexutil.Bytes,

--- a/op-enclave/enclave/rpc.go
+++ b/op-enclave/enclave/rpc.go
@@ -2,6 +2,7 @@ package enclave
 
 import (
 	"context"
+	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
@@ -26,7 +27,7 @@ type RPC interface {
 		chainConfig *params.ChainConfig,
 		l1Origin *types.Header,
 		l1Receipts types.Receipts,
-		l1Txs []hexutil.Bytes,
+		l1BaseFee *big.Int,
 		previousBlockTxs []hexutil.Bytes,
 		blockHeader *types.Header,
 		sequencedTxs []hexutil.Bytes,

--- a/op-enclave/enclave/server.go
+++ b/op-enclave/enclave/server.go
@@ -247,6 +247,7 @@ func (s *Server) ExecuteStateless(
 	chainConfig *params.ChainConfig,
 	l1Origin *types.Header,
 	l1Receipts types.Receipts,
+	l1Txs []hexutil.Bytes,
 	previousBlockTxs []hexutil.Bytes,
 	blockHeader *types.Header,
 	sequencedTxs []hexutil.Bytes,
@@ -273,7 +274,7 @@ func (s *Server) ExecuteStateless(
 	previousBlockHeader := w.Headers[0]
 
 	err = ExecuteStateless(ctx, config.ChainConfig, config.ToRollupConfig(),
-		l1Origin, l1Receipts, previousBlockTxs, blockHeader, sequencedTxs, w, messageAccount)
+		l1Origin, l1Receipts, l1Txs, previousBlockTxs, blockHeader, sequencedTxs, w, messageAccount)
 	if err != nil {
 		return nil, err
 	}

--- a/op-enclave/enclave/server.go
+++ b/op-enclave/enclave/server.go
@@ -247,7 +247,7 @@ func (s *Server) ExecuteStateless(
 	chainConfig *params.ChainConfig,
 	l1Origin *types.Header,
 	l1Receipts types.Receipts,
-	l1Txs []hexutil.Bytes,
+	l1BaseFee *big.Int,
 	previousBlockTxs []hexutil.Bytes,
 	blockHeader *types.Header,
 	sequencedTxs []hexutil.Bytes,
@@ -274,7 +274,7 @@ func (s *Server) ExecuteStateless(
 	previousBlockHeader := w.Headers[0]
 
 	err = ExecuteStateless(ctx, config.ChainConfig, config.ToRollupConfig(),
-		l1Origin, l1Receipts, l1Txs, previousBlockTxs, blockHeader, sequencedTxs, w, messageAccount)
+		l1Origin, l1Receipts, l1BaseFee, previousBlockTxs, blockHeader, sequencedTxs, w, messageAccount)
 	if err != nil {
 		return nil, err
 	}

--- a/op-enclave/enclave/stateless.go
+++ b/op-enclave/enclave/stateless.go
@@ -65,6 +65,11 @@ func ExecuteStateless(
 		}
 		return txs, nil
 	}
+	l1Txs, err := unmarshalTxs(encodedL1Txs)
+	if err != nil {
+		return err
+	}
+
 	previousTxs, err := unmarshalTxs(previousBlockTxs)
 	if err != nil {
 		return err
@@ -74,13 +79,9 @@ func ExecuteStateless(
 	if previousTxHash != previousBlockHeader.TxHash {
 		return errors.New("invalid tx hash")
 	}
-	l1Txs, err := unmarshalTxs(encodedL1Txs)
-	if err != nil {
-		return err
-	}
 
 	previousBlock := types.NewBlockWithHeader(previousBlockHeader).WithBody(types.Body{
-		Transactions: append(l1Txs, previousTxs...),
+		Transactions: previousTxs,
 	})
 
 	l2Parent, err := derive.L2BlockToBlockRef(rollupConfig, previousBlock)

--- a/op-enclave/enclave/stateless.go
+++ b/op-enclave/enclave/stateless.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/big"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
@@ -25,7 +26,7 @@ func ExecuteStateless(
 	rollupConfig *rollup.Config,
 	l1Origin *types.Header,
 	l1Receipts types.Receipts,
-	encodedL1Txs []hexutil.Bytes,
+	l1BaseFee *big.Int,
 	previousBlockTxs []hexutil.Bytes,
 	blockHeader *types.Header,
 	sequencedTxs []hexutil.Bytes,
@@ -67,10 +68,10 @@ func ExecuteStateless(
 		}
 		return txs, nil
 	}
-	l1Txs, err := unmarshalTxs(encodedL1Txs)
-	if err != nil {
-		return err
-	}
+	// l1Txs, err := unmarshalTxs(encodedL1Txs)
+	// if err != nil {
+	// 	return err
+	// }
 
 	previousTxs, err := unmarshalTxs(previousBlockTxs)
 	if err != nil {
@@ -96,7 +97,7 @@ func ExecuteStateless(
 	}
 
 	log.Warn("debug witness, new l1 receipts fetcher", "l1_origin_hash", l1OriginHash, "l1_origin_block", l1Origin)
-	l1Fetcher := NewL1ReceiptsFetcher(l1OriginHash, l1Origin, l1Receipts, l1Txs, config)
+	l1Fetcher := NewL1ReceiptsFetcher(l1OriginHash, l1Origin, l1Receipts, config)
 	l2Fetcher := NewL2SystemConfigFetcher(rollupConfig, previousBlockHash, previousBlockHeader, previousTxs)
 	attributeBuilder := derive.NewFetchingAttributesBuilder(rollupConfig, l1Fetcher, l2Fetcher)
 	log.Warn("debug witness, prepare payload attributes in tee", "l2_parent", l2Parent, "epoch", eth.BlockID{
@@ -106,7 +107,7 @@ func ExecuteStateless(
 	payload, err := attributeBuilder.PreparePayloadAttributes(ctx, l2Parent, eth.BlockID{
 		Hash:   l1OriginHash,
 		Number: l1Origin.Number.Uint64(),
-	})
+	}, l1BaseFee)
 	if err != nil {
 		return fmt.Errorf("failed to prepare payload attributes: %w", err)
 	}

--- a/op-enclave/enclave/stateless.go
+++ b/op-enclave/enclave/stateless.go
@@ -95,9 +95,14 @@ func ExecuteStateless(
 		return errors.New("invalid L1 origin")
 	}
 
+	log.Warn("debug witness, new l1 receipts fetcher", "l1_origin_hash", l1OriginHash, "l1_origin_block", l1Origin)
 	l1Fetcher := NewL1ReceiptsFetcher(l1OriginHash, l1Origin, l1Receipts, l1Txs, config)
 	l2Fetcher := NewL2SystemConfigFetcher(rollupConfig, previousBlockHash, previousBlockHeader, previousTxs)
 	attributeBuilder := derive.NewFetchingAttributesBuilder(rollupConfig, l1Fetcher, l2Fetcher)
+	log.Warn("debug witness, prepare payload attributes in tee", "l2_parent", l2Parent, "epoch", eth.BlockID{
+		Hash:   l1OriginHash,
+		Number: l1Origin.Number.Uint64(),
+	})
 	payload, err := attributeBuilder.PreparePayloadAttributes(ctx, l2Parent, eth.BlockID{
 		Hash:   l1OriginHash,
 		Number: l1Origin.Number.Uint64(),

--- a/op-enclave/enclave/stateless.go
+++ b/op-enclave/enclave/stateless.go
@@ -68,10 +68,6 @@ func ExecuteStateless(
 		}
 		return txs, nil
 	}
-	// l1Txs, err := unmarshalTxs(encodedL1Txs)
-	// if err != nil {
-	// 	return err
-	// }
 
 	previousTxs, err := unmarshalTxs(previousBlockTxs)
 	if err != nil {

--- a/op-enclave/enclave/stateless.go
+++ b/op-enclave/enclave/stateless.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/stateless"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/trie"
 )
@@ -24,12 +25,19 @@ func ExecuteStateless(
 	rollupConfig *rollup.Config,
 	l1Origin *types.Header,
 	l1Receipts types.Receipts,
+	encodedL1Txs []hexutil.Bytes,
 	previousBlockTxs []hexutil.Bytes,
 	blockHeader *types.Header,
 	sequencedTxs []hexutil.Bytes,
 	witness *stateless.Witness,
 	messageAccount *eth.AccountResult,
 ) error {
+	log.Warn("debug witness, ExecuteStateless in tee",
+		"l1_origin_block", l1Origin,
+		"l1_receipts", l1Receipts,
+		"block_header", blockHeader,
+		"sequenced_txs", sequencedTxs,
+	)
 	l1OriginHash := l1Origin.Hash()
 	computed := types.DeriveSha(l1Receipts, trie.NewStackTrie(nil))
 	if computed != l1Origin.ReceiptHash {
@@ -66,9 +74,13 @@ func ExecuteStateless(
 	if previousTxHash != previousBlockHeader.TxHash {
 		return errors.New("invalid tx hash")
 	}
+	l1Txs, err := unmarshalTxs(encodedL1Txs)
+	if err != nil {
+		return err
+	}
 
 	previousBlock := types.NewBlockWithHeader(previousBlockHeader).WithBody(types.Body{
-		Transactions: previousTxs,
+		Transactions: append(l1Txs, previousTxs...),
 	})
 
 	l2Parent, err := derive.L2BlockToBlockRef(rollupConfig, previousBlock)
@@ -80,7 +92,7 @@ func ExecuteStateless(
 		return errors.New("invalid L1 origin")
 	}
 
-	l1Fetcher := NewL1ReceiptsFetcher(l1OriginHash, l1Origin, l1Receipts, config)
+	l1Fetcher := NewL1ReceiptsFetcher(l1OriginHash, l1Origin, l1Receipts, l1Txs, config)
 	l2Fetcher := NewL2SystemConfigFetcher(rollupConfig, previousBlockHash, previousBlockHeader, previousTxs)
 	attributeBuilder := derive.NewFetchingAttributesBuilder(rollupConfig, l1Fetcher, l2Fetcher)
 	payload, err := attributeBuilder.PreparePayloadAttributes(ctx, l2Parent, eth.BlockID{

--- a/op-enclave/enclave/stateless.go
+++ b/op-enclave/enclave/stateless.go
@@ -151,6 +151,6 @@ func ExecuteStateless(
 	if err = messageAccount.Verify(blockHeader.Root); err != nil {
 		return fmt.Errorf("failed to verify message account: %w", err)
 	}
-
+	log.Info("debug witness, succed to stateless execution in tee", "l2_block", block)
 	return nil
 }

--- a/op-enclave/enclave/stateless.go
+++ b/op-enclave/enclave/stateless.go
@@ -32,13 +32,15 @@ func ExecuteStateless(
 	witness *stateless.Witness,
 	messageAccount *eth.AccountResult,
 ) error {
-	log.Warn("debug witness, ExecuteStateless in tee",
-		"l1_origin_block", l1Origin,
+	l1OriginHash := l1Origin.Hash()
+	log.Warn("debug witness, execute stateless in tee",
+		"l1_origin_header", l1Origin,
 		"l1_receipts", l1Receipts,
+		"l1_origin_hash", l1OriginHash,
+		"l1_origin_parent_hash", l1Origin.ParentHash,
 		"block_header", blockHeader,
 		"sequenced_txs", sequencedTxs,
 	)
-	l1OriginHash := l1Origin.Hash()
 	computed := types.DeriveSha(l1Receipts, trie.NewStackTrie(nil))
 	if computed != l1Origin.ReceiptHash {
 		return errors.New("invalid receipts")

--- a/op-enclave/go.mod
+++ b/op-enclave/go.mod
@@ -137,10 +137,7 @@ require (
 // replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101503.2
 
 // https://github.com/bnb-chain/opbnb/tree/adapt_enclave import op-batcher/op-proposer
-//replace github.com/ethereum-optimism/optimism => github.com/bnb-chain/opbnb v0.5.4-0.20250516033433-d1421717d681
-
-// https://github.com/will-2012/opbnb/tree/new-adapt-enclave
-replace github.com/ethereum-optimism/optimism => github.com/will-2012/opbnb v0.0.0-20250523064839-a6ca7497dc40
+replace github.com/ethereum-optimism/optimism => github.com/bnb-chain/opbnb v0.5.4-0.20250523084526-116cdea15e13
 
 // https://github.com/bnb-chain/op-geth/tree/tmp_7702_witness, depend core.ExecuteWitness
 replace github.com/ethereum/go-ethereum => github.com/bnb-chain/op-geth v1.101315.2-0.0.20250516112649-809fafe48823

--- a/op-enclave/go.mod
+++ b/op-enclave/go.mod
@@ -137,7 +137,10 @@ require (
 // replace github.com/ethereum/go-ethereum => github.com/ethereum-optimism/op-geth v1.101503.2
 
 // https://github.com/bnb-chain/opbnb/tree/adapt_enclave import op-batcher/op-proposer
-replace github.com/ethereum-optimism/optimism => github.com/bnb-chain/opbnb v0.5.4-0.20250516033433-d1421717d681
+//replace github.com/ethereum-optimism/optimism => github.com/bnb-chain/opbnb v0.5.4-0.20250516033433-d1421717d681
+
+// https://github.com/will-2012/opbnb/tree/new-adapt-enclave
+replace github.com/ethereum-optimism/optimism => github.com/will-2012/opbnb new-adapt-enclave
 
 // https://github.com/bnb-chain/op-geth/tree/tmp_7702_witness, depend core.ExecuteWitness
 replace github.com/ethereum/go-ethereum => github.com/bnb-chain/op-geth v1.101315.2-0.0.20250516112649-809fafe48823

--- a/op-enclave/go.mod
+++ b/op-enclave/go.mod
@@ -140,7 +140,7 @@ require (
 //replace github.com/ethereum-optimism/optimism => github.com/bnb-chain/opbnb v0.5.4-0.20250516033433-d1421717d681
 
 // https://github.com/will-2012/opbnb/tree/new-adapt-enclave
-replace github.com/ethereum-optimism/optimism => github.com/will-2012/opbnb new-adapt-enclave
+replace github.com/ethereum-optimism/optimism => github.com/will-2012/opbnb v0.0.0-20250523064839-a6ca7497dc40
 
 // https://github.com/bnb-chain/op-geth/tree/tmp_7702_witness, depend core.ExecuteWitness
 replace github.com/ethereum/go-ethereum => github.com/bnb-chain/op-geth v1.101315.2-0.0.20250516112649-809fafe48823

--- a/op-enclave/go.sum
+++ b/op-enclave/go.sum
@@ -981,8 +981,6 @@ github.com/bnb-chain/greenfield-cometbft v1.0.0 h1:0r6hOJWD/+es0gxP/exKuN/krgXAr
 github.com/bnb-chain/greenfield-cometbft v1.0.0/go.mod h1:f35mk/r5ab6yvzlqEWZt68LfUje68sYgMpVlt2CUYMk=
 github.com/bnb-chain/op-geth v1.101315.2-0.0.20250516112649-809fafe48823 h1:hRTt36s9UHkUNCFFDI+1ulFJOg19l0h/X+z9TJ8vtzw=
 github.com/bnb-chain/op-geth v1.101315.2-0.0.20250516112649-809fafe48823/go.mod h1:hyHrrcHkUe3lRwfJs+JGrbOHp+pRdheRk+ren4TPhF8=
-github.com/bnb-chain/opbnb v0.5.4-0.20250516033433-d1421717d681 h1:qRqerrAnTAURNOa1AsLRdp6oBbQhReP49+AlODdk9NY=
-github.com/bnb-chain/opbnb v0.5.4-0.20250516033433-d1421717d681/go.mod h1:3jT4l7WSDmDyFcADb4auox2mkOd/Tn5dQ/aLBPzaY9Y=
 github.com/bombsimon/wsl/v2 v2.0.0/go.mod h1:mf25kr/SqFEPhhcxW1+7pxzGlW+hIl/hYTKY95VwV8U=
 github.com/bombsimon/wsl/v2 v2.2.0/go.mod h1:Azh8c3XGEJl9LyX0/sFC+CKMc7Ssgua0g+6abzXN4Pg=
 github.com/bombsimon/wsl/v3 v3.0.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=

--- a/op-enclave/go.sum
+++ b/op-enclave/go.sum
@@ -981,6 +981,8 @@ github.com/bnb-chain/greenfield-cometbft v1.0.0 h1:0r6hOJWD/+es0gxP/exKuN/krgXAr
 github.com/bnb-chain/greenfield-cometbft v1.0.0/go.mod h1:f35mk/r5ab6yvzlqEWZt68LfUje68sYgMpVlt2CUYMk=
 github.com/bnb-chain/op-geth v1.101315.2-0.0.20250516112649-809fafe48823 h1:hRTt36s9UHkUNCFFDI+1ulFJOg19l0h/X+z9TJ8vtzw=
 github.com/bnb-chain/op-geth v1.101315.2-0.0.20250516112649-809fafe48823/go.mod h1:hyHrrcHkUe3lRwfJs+JGrbOHp+pRdheRk+ren4TPhF8=
+github.com/bnb-chain/opbnb v0.5.4-0.20250523084526-116cdea15e13 h1:nba63VbYo3dAllaX3Jr5GjgnTqvSKOWvH5D23D1FEb4=
+github.com/bnb-chain/opbnb v0.5.4-0.20250523084526-116cdea15e13/go.mod h1:f79+CBEK7HYPacx80akhTpzUaGZDe+tQR53TwNgFQKI=
 github.com/bombsimon/wsl/v2 v2.0.0/go.mod h1:mf25kr/SqFEPhhcxW1+7pxzGlW+hIl/hYTKY95VwV8U=
 github.com/bombsimon/wsl/v2 v2.2.0/go.mod h1:Azh8c3XGEJl9LyX0/sFC+CKMc7Ssgua0g+6abzXN4Pg=
 github.com/bombsimon/wsl/v3 v3.0.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=
@@ -3655,8 +3657,6 @@ github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc/go.mod h1
 github.com/whyrusleeping/mdns v0.0.0-20190826153040-b9b60ed33aa9/go.mod h1:j4l84WPFclQPj320J9gp0XwNKBb3U0zt5CBqjPp22G4=
 github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7/go.mod h1:X2c0RVCI1eSUFI8eLcY3c0423ykwiUdxLJtkDvruhjI=
 github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee/go.mod h1:m2aV4LZI4Aez7dP5PMyVKEHhUyEJ/RjmPEDOpDvudHg=
-github.com/will-2012/opbnb v0.0.0-20250523064839-a6ca7497dc40 h1:72NTJL67fX+YQ/E5vEnmFtNQ5KjoDaKdTuyw4d/aysY=
-github.com/will-2012/opbnb v0.0.0-20250523064839-a6ca7497dc40/go.mod h1:f79+CBEK7HYPacx80akhTpzUaGZDe+tQR53TwNgFQKI=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2/go.mod h1:2duySbKsL6M18s5GU7VPsoEPHyzalCE06qoARUCeBBE=

--- a/op-enclave/go.sum
+++ b/op-enclave/go.sum
@@ -3655,6 +3655,8 @@ github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc/go.mod h1
 github.com/whyrusleeping/mdns v0.0.0-20190826153040-b9b60ed33aa9/go.mod h1:j4l84WPFclQPj320J9gp0XwNKBb3U0zt5CBqjPp22G4=
 github.com/whyrusleeping/multiaddr-filter v0.0.0-20160516205228-e903e4adabd7/go.mod h1:X2c0RVCI1eSUFI8eLcY3c0423ykwiUdxLJtkDvruhjI=
 github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee/go.mod h1:m2aV4LZI4Aez7dP5PMyVKEHhUyEJ/RjmPEDOpDvudHg=
+github.com/will-2012/opbnb v0.0.0-20250523064839-a6ca7497dc40 h1:72NTJL67fX+YQ/E5vEnmFtNQ5KjoDaKdTuyw4d/aysY=
+github.com/will-2012/opbnb v0.0.0-20250523064839-a6ca7497dc40/go.mod h1:f79+CBEK7HYPacx80akhTpzUaGZDe+tQR53TwNgFQKI=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/x-cray/logrus-prefixed-formatter v0.5.2/go.mod h1:2duySbKsL6M18s5GU7VPsoEPHyzalCE06qoARUCeBBE=

--- a/op-proposer/proposer/clients.go
+++ b/op-proposer/proposer/clients.go
@@ -21,6 +21,7 @@ type L1Client interface {
 	HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error)
 	HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error)
 	BlockReceipts(ctx context.Context, hash common.Hash) (types.Receipts, error)
+	BlockTransactions(ctx context.Context, hash common.Hash) (types.Transactions, error)
 	CodeAt(ctx context.Context, contract common.Address, blockNumber *big.Int) ([]byte, error)
 	CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error)
 	Close()
@@ -136,6 +137,14 @@ func (e *ethClient) BlockReceipts(ctx context.Context, hash common.Hash) (types.
 	}
 	e.receiptsCache.Add(hash, receipts)
 	return receipts, nil
+}
+
+func (e *ethClient) BlockTransactions(ctx context.Context, hash common.Hash) (types.Transactions, error) {
+	block, err := e.BlockByHash(ctx, hash)
+	if err != nil {
+		return nil, err
+	}
+	return block.Transactions(), nil
 }
 
 func (e *ethClient) CodeAt(ctx context.Context, contract common.Address, blockNumber *big.Int) ([]byte, error) {

--- a/op-proposer/proposer/clients.go
+++ b/op-proposer/proposer/clients.go
@@ -22,6 +22,7 @@ type L1Client interface {
 	HeaderByHash(ctx context.Context, hash common.Hash) (*types.Header, error)
 	BlockReceipts(ctx context.Context, hash common.Hash) (types.Receipts, error)
 	BlockTransactions(ctx context.Context, hash common.Hash) (types.Transactions, error)
+	InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error)
 	CodeAt(ctx context.Context, contract common.Address, blockNumber *big.Int) ([]byte, error)
 	CallContract(ctx context.Context, call ethereum.CallMsg, blockNumber *big.Int) ([]byte, error)
 	Close()
@@ -145,6 +146,14 @@ func (e *ethClient) BlockTransactions(ctx context.Context, hash common.Hash) (ty
 		return nil, err
 	}
 	return block.Transactions(), nil
+}
+
+func (e *ethClient) InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error) {
+	block, err := e.BlockByHash(ctx, hash)
+	if err != nil {
+		return nil, nil, err
+	}
+	return eth.BlockToInfo(block), block.Transactions(), nil
 }
 
 func (e *ethClient) CodeAt(ctx context.Context, contract common.Address, blockNumber *big.Int) ([]byte, error) {

--- a/op-proposer/proposer/l1_base_fee.go
+++ b/op-proposer/proposer/l1_base_fee.go
@@ -1,0 +1,83 @@
+package proposer
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
+	"github.com/ethereum-optimism/optimism/op-service/bsc"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+var (
+	_       derive.L1ReceiptsFetcher = &l1ReceiptsFetcher{}
+	fetcher *l1ReceiptsFetcher
+)
+
+type l1ReceiptsFetcher struct {
+	l1 L1Client
+}
+
+func (f *l1ReceiptsFetcher) ClearReceiptsCacheBefore(blockNum uint64) {
+	// No-op implementation since this fetcher doesn't maintain a cache
+}
+
+func (f *l1ReceiptsFetcher) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {
+	return nil, nil, fmt.Errorf("FetchReceipts not implemented")
+}
+
+func (f *l1ReceiptsFetcher) GoOrUpdatePreFetchReceipts(ctx context.Context, blockNum uint64) error {
+	// No-op implementation since this fetcher doesn't maintain a cache
+	return nil
+}
+
+func (f *l1ReceiptsFetcher) InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error) {
+	return f.l1.InfoAndTxsByHash(ctx, hash)
+	//return nil, nil, fmt.Errorf("InfoAndTxsByHash not implemented")
+}
+
+func (f *l1ReceiptsFetcher) InfoByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, error) {
+	return nil, fmt.Errorf("InfoByHash not implemented")
+}
+
+func (f *l1ReceiptsFetcher) PreFetchReceipts(ctx context.Context, blockHash common.Hash) (bool, error) {
+	return false, nil // No-op implementation
+}
+
+// CalculateL1BaseFee calculates the L1 base fee for a given block.
+func (p *Prover) calculateL1BaseFee(ctx context.Context, l2Parent eth.L2BlockRef, epoch eth.BlockID) (*big.Int, error) {
+	var (
+		l1BaseFee *big.Int
+		err       error
+	)
+	if fetcher == nil {
+		fetcher = &l1ReceiptsFetcher{l1: p.l1}
+	}
+	if p.rollupCfg.IsSnow(p.rollupCfg.NextSecondBlockTime(l2Parent.MillisecondTimestamp())) {
+		l1BaseFee, err = calculateSnowL1GasPrice(ctx, fetcher, epoch)
+		if err != nil {
+			return nil, err
+		}
+	} else if p.rollupCfg.IsFermat(big.NewInt(int64(l2Parent.Number + 1))) {
+		l1BaseFee = bsc.BaseFeeByNetworks(p.rollupCfg.L2ChainID)
+	} else {
+		_, transactions, err := fetcher.InfoAndTxsByHash(ctx, epoch.Hash)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch L1 block info and txs: %w", err)
+		}
+		l1BaseFee = bsc.BaseFeeByTransactions(transactions)
+	}
+	return l1BaseFee, nil
+}
+
+func calculateSnowL1GasPrice(ctx context.Context, fetcher derive.L1ReceiptsFetcher, epoch eth.BlockID) (*big.Int, error) {
+	ba := derive.NewFetchingAttributesBuilder(nil, fetcher, nil)
+	l1BaseFee, err := derive.SnowL1GasPrice(ctx, ba, epoch)
+	if err != nil {
+		return nil, err
+	}
+	return l1BaseFee, nil
+}

--- a/op-proposer/proposer/l1_base_fee.go
+++ b/op-proposer/proposer/l1_base_fee.go
@@ -36,7 +36,6 @@ func (f *l1ReceiptsFetcher) GoOrUpdatePreFetchReceipts(ctx context.Context, bloc
 
 func (f *l1ReceiptsFetcher) InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error) {
 	return f.l1.InfoAndTxsByHash(ctx, hash)
-	//return nil, nil, fmt.Errorf("InfoAndTxsByHash not implemented")
 }
 
 func (f *l1ReceiptsFetcher) InfoByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, error) {
@@ -48,6 +47,7 @@ func (f *l1ReceiptsFetcher) PreFetchReceipts(ctx context.Context, blockHash comm
 }
 
 // CalculateL1BaseFee calculates the L1 base fee for a given block.
+// Need keep consistent with https://github.com/bnb-chain/opbnb/blob/4fde65a8ff1956d9756855d719dac3c93166ff50/op-node/rollup/derive/attributes.go#L110-L124.
 func (p *Prover) calculateL1BaseFee(ctx context.Context, l2Parent eth.L2BlockRef, epoch eth.BlockID) (*big.Int, error) {
 	var (
 		l1BaseFee *big.Int

--- a/op-proposer/proposer/prover.go
+++ b/op-proposer/proposer/prover.go
@@ -106,20 +106,6 @@ func (o *Prover) Generate(ctx context.Context, block *types.Block) (*Proposal, e
 		return fmt.Errorf("failed to fetch L1 receipts: %w", err)
 	})
 
-	l1TxsCh := await(func() (types.Transactions, error) {
-		return o.l1.BlockTransactions(ctx, blockRef.L1Origin.Hash)
-	}, func(err error) error {
-		return fmt.Errorf("failed to fetch L1 txs: %w", err)
-	})
-
-	// l1BaseFeeCh := await(func() (*big.Int, error) {
-	// 	return o.calculateL1BaseFee(ctx, blockRef, blockRef.L1Origin.Number)
-	// }, func(err error) error {
-	// 	return fmt.Errorf("failed to fetch L1 base fee: %w", err)
-	// })
-
-	// _ = l1BaseFeeCh
-
 	var errors []error
 
 	witness := <-witnessCh
@@ -136,9 +122,6 @@ func (o *Prover) Generate(ctx context.Context, block *types.Block) (*Proposal, e
 
 	l1Receipts := <-l1ReceiptsCh
 	errors = appendNonNil(errors, l1Receipts.err)
-
-	l1Txs := <-l1TxsCh
-	errors = appendNonNil(errors, l1Txs.err)
 
 	prevMessageAccount := <-prevMessageAccountCh
 	errors = appendNonNil(errors, prevMessageAccount.err)
@@ -169,14 +152,9 @@ func (o *Prover) Generate(ctx context.Context, block *types.Block) (*Proposal, e
 	if err != nil {
 		return nil, err
 	}
-	encodedL1Txs, err := marshalTxs(l1Txs.value, false)
-	if err != nil {
-		return nil, err
-	}
 
 	var l1BaseFee *big.Int
-	{ // prepare l1 base fee for l1 info deposit tx of the l2 block
-		// l2 parent + l1 origin
+	{ // prepare l1 base fee for l1 info deposit tx of the l2 block, need l2_parent + l1_origin.
 		previousBlock := types.NewBlockWithHeader(witness.value.Headers[0]).WithBody(types.Body{
 			Transactions: previousBlock.value.Transactions(),
 		})
@@ -193,7 +171,6 @@ func (o *Prover) Generate(ctx context.Context, block *types.Block) (*Proposal, e
 			return nil, fmt.Errorf("failed to calculate L1 base fee: %w", err)
 		}
 	}
-	_ = encodedL1Txs
 
 	output, err := o.enclave.ExecuteStateless(
 		ctx,

--- a/op-proposer/proposer/prover.go
+++ b/op-proposer/proposer/prover.go
@@ -3,8 +3,10 @@ package proposer
 import (
 	"context"
 	"fmt"
+	"math/big"
 
 	"github.com/base/op-enclave/op-enclave/enclave"
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
@@ -12,11 +14,13 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/stateless"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/hashicorp/go-multierror"
 )
 
 type Prover struct {
+	rollupCfg   *rollup.Config
 	config      *enclave.PerChainConfig
 	chainConfig *params.ChainConfig
 	configHash  common.Hash
@@ -48,7 +52,9 @@ func NewProver(
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch chain config: %w", err)
 	}
+	log.Info("succeed to new proposer", "chain_config", chainConfig, "rollup_config", rollupConfig)
 	return &Prover{
+		rollupCfg:   rollupConfig,
 		config:      cfg,
 		chainConfig: chainConfig,
 		configHash:  cfg.Hash(),
@@ -106,6 +112,14 @@ func (o *Prover) Generate(ctx context.Context, block *types.Block) (*Proposal, e
 		return fmt.Errorf("failed to fetch L1 txs: %w", err)
 	})
 
+	// l1BaseFeeCh := await(func() (*big.Int, error) {
+	// 	return o.calculateL1BaseFee(ctx, blockRef, blockRef.L1Origin.Number)
+	// }, func(err error) error {
+	// 	return fmt.Errorf("failed to fetch L1 base fee: %w", err)
+	// })
+
+	// _ = l1BaseFeeCh
+
 	var errors []error
 
 	witness := <-witnessCh
@@ -160,13 +174,34 @@ func (o *Prover) Generate(ctx context.Context, block *types.Block) (*Proposal, e
 		return nil, err
 	}
 
+	var l1BaseFee *big.Int
+	{ // prepare l1 base fee for l1 info deposit tx of the l2 block
+		// l2 parent + l1 origin
+		previousBlock := types.NewBlockWithHeader(witness.value.Headers[0]).WithBody(types.Body{
+			Transactions: previousBlock.value.Transactions(),
+		})
+
+		l2Parent, err := derive.L2BlockToBlockRef(o.rollupCfg, previousBlock)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert parent L2 block to block ref: %w", err)
+		}
+		l1BaseFee, err = o.calculateL1BaseFee(ctx, l2Parent, eth.BlockID{
+			Hash:   l1Origin.value.Hash(),
+			Number: l1Origin.value.Number.Uint64(),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to calculate L1 base fee: %w", err)
+		}
+	}
+	_ = encodedL1Txs
+
 	output, err := o.enclave.ExecuteStateless(
 		ctx,
 		o.config,
 		o.chainConfig,
 		l1Origin.value,
 		l1Receipts.value,
-		encodedL1Txs,
+		l1BaseFee, // l1 base fee for l1 info deposit tx of the l2 block
 		previousTxs,
 		block.Header(),
 		sequencedTxs,

--- a/op-proposer/proposer/prover.go
+++ b/op-proposer/proposer/prover.go
@@ -100,6 +100,12 @@ func (o *Prover) Generate(ctx context.Context, block *types.Block) (*Proposal, e
 		return fmt.Errorf("failed to fetch L1 receipts: %w", err)
 	})
 
+	l1TxsCh := await(func() (types.Transactions, error) {
+		return o.l1.BlockTransactions(ctx, blockRef.L1Origin.Hash)
+	}, func(err error) error {
+		return fmt.Errorf("failed to fetch L1 txs: %w", err)
+	})
+
 	var errors []error
 
 	witness := <-witnessCh
@@ -116,6 +122,9 @@ func (o *Prover) Generate(ctx context.Context, block *types.Block) (*Proposal, e
 
 	l1Receipts := <-l1ReceiptsCh
 	errors = appendNonNil(errors, l1Receipts.err)
+
+	l1Txs := <-l1TxsCh
+	errors = appendNonNil(errors, l1Txs.err)
 
 	prevMessageAccount := <-prevMessageAccountCh
 	errors = appendNonNil(errors, prevMessageAccount.err)
@@ -146,6 +155,10 @@ func (o *Prover) Generate(ctx context.Context, block *types.Block) (*Proposal, e
 	if err != nil {
 		return nil, err
 	}
+	encodedL1Txs, err := marshalTxs(l1Txs.value, false)
+	if err != nil {
+		return nil, err
+	}
 
 	output, err := o.enclave.ExecuteStateless(
 		ctx,
@@ -153,6 +166,7 @@ func (o *Prover) Generate(ctx context.Context, block *types.Block) (*Proposal, e
 		o.chainConfig,
 		l1Origin.value,
 		l1Receipts.value,
+		encodedL1Txs,
 		previousTxs,
 		block.Header(),
 		sequencedTxs,


### PR DESCRIPTION
### Description

Adapt stateless call PreparePayloadAttributes with https://github.com/bnb-chain/opbnb/pull/300.

### Rationale

OP-enclave calculates l1 base fee out of PreparePayloadAttributes, and their logic is completely consistent.

### Example

N/A.

### Changes

Notable changes:
* PreparePayloadAttributes related code